### PR TITLE
flatten input_data parameters

### DIFF
--- a/envs/load_data.yaml
+++ b/envs/load_data.yaml
@@ -5,4 +5,4 @@ channels:
   - defaults
   - ebi-gene-expression-group
 dependencies:
-  - atlas-data-import=0.0.3
+  - atlas-data-import=0.0.4

--- a/main.nf
+++ b/main.nf
@@ -109,11 +109,11 @@ if(params.data_download.run == "True"){
     }
     
 }else{
-   	REF_10X_DIR = Channel.fromPath(params.input_data.ref_10x_dir).first()
-   	QUERY_10X_DIR = Channel.fromPath(params.input_data.query_10x_dir).first()
-   	UNMELT_SDRF_REF = Channel.fromPath(params.input_data.unmelt_sdrf_ref).first()
-   	UNMELTED_SDRF_QUERY = Channel.fromPath(params.input_data.unmelt_sdrf_query).first()
-    	REF_MARKERS = Channel.fromPath(params.input_data.ref_markers).first()
+   	REF_10X_DIR = Channel.fromPath(params.ref_10x_dir).first()
+   	QUERY_10X_DIR = Channel.fromPath(params.query_10x_dir).first()
+   	UNMELT_SDRF_REF = Channel.fromPath(params.unmelt_sdrf_ref).first()
+   	UNMELTED_SDRF_QUERY = Channel.fromPath(params.unmelt_sdrf_query).first()
+    	REF_MARKERS = Channel.fromPath(params.ref_markers).first()
 }
 
 //run garnett 

--- a/main.nf
+++ b/main.nf
@@ -109,11 +109,11 @@ if(params.data_download.run == "True"){
     }
     
 }else{
-   	REF_10X_DIR = Channel.fromPath(params.ref_10x_dir).first()
-   	QUERY_10X_DIR = Channel.fromPath(params.query_10x_dir).first()
-   	UNMELT_SDRF_REF = Channel.fromPath(params.unmelt_sdrf_ref).first()
-   	UNMELTED_SDRF_QUERY = Channel.fromPath(params.unmelt_sdrf_query).first()
-    	REF_MARKERS = Channel.fromPath(params.ref_markers).first()
+   	REF_10X_DIR = Channel.fromPath(params.ref_10x_dir, checkIfExists: true).first()
+   	QUERY_10X_DIR = Channel.fromPath(params.query_10x_dir, checkIfExists: true).first()
+   	UNMELT_SDRF_REF = Channel.fromPath(params.unmelt_sdrf_ref, checkIfExists: true).first()
+   	UNMELTED_SDRF_QUERY = Channel.fromPath(params.unmelt_sdrf_query, checkIfExists: true).first()
+    	REF_MARKERS = Channel.fromPath(params.ref_markers, checkIfExists: true).first()
 }
 
 //run garnett 

--- a/nextflow.config
+++ b/nextflow.config
@@ -154,7 +154,7 @@ params {
 
 env { 
     CONTROL_WORKFLOW_ROOT = "${baseDir}"
-    CONTROL_WORKFLOW_BRANCH = 'origin/feature/cross_validation'
+    CONTROL_WORKFLOW_BRANCH = 'origin/develop'
 
     EVAL_WORKFLOWS = "${baseDir}/cell-types-eval-workflows"
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -23,9 +23,16 @@ params {
     tool_outputs_dir ="${baseDir}/data/tools_outputs"
     label_analysis_outdir ="${baseDir}/data/tools_outputs"
 
+    // Specify input data. If data_download = 'False'
+    ref_10x_dir = ""
+    query_10x_dir = ""
+    unmelt_sdrf_ref = "" // un-melted metadata ref file
+    unmelt_sdrf_query = "" // un-melted metadata ref file
+    ref_markers= ""
+    
     // links to download data 
     data_download{
-        run = "True" // must be 'True' or 'False'      
+        run = "False" // must be 'True' or 'False'      
         expr_data_type = "normalised"
         normalisation_method = "TPM"
 
@@ -38,15 +45,6 @@ params {
         query_num_clust = 11 
     }
     
-    // Specify input data. If data_download = 'False'
-    input_data{
-        ref_10x_dir = ""
-        query_10x_dir = ""
-        unmelt_sdrf_ref = "" // un-melted metadata ref file
-        unmelt_sdrf_query = "" // un-melted metadata ref file
-        ref_markers= ""
-    }
-
     // contol field names in metadata file 
     metadata{
         query_barcode_col_name = "id" // cell id column 
@@ -156,7 +154,7 @@ params {
 
 env { 
     CONTROL_WORKFLOW_ROOT = "${baseDir}"
-    CONTROL_WORKFLOW_BRANCH = 'origin/develop'
+    CONTROL_WORKFLOW_BRANCH = 'origin/feature/cross_validation'
 
     EVAL_WORKFLOWS = "${baseDir}/cell-types-eval-workflows"
 


### PR DESCRIPTION
This PR is simply to flatten the input data parameters in the config file, so that they can be accessed by an upstream workflow. 
If config parameters are organized in scopes (as params{input_data{data_file = "abc.tsv"}}) then they cannot be overwritten. So I took input_data parameters out of their scope.
