### PR TITLE
Remove Submodules 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "cell-types-eval-workflows"]
-	path = cell-types-eval-workflows
-	url = https://github.com/ebi-gene-expression-group/cell-types-eval-workflows.git
-	branch = develop

--- a/main.nf
+++ b/main.nf
@@ -132,12 +132,12 @@ if(params.garnett.run == "True"){
             file(ref_markers) from REF_MARKERS
 
         output:
-             file("final_garnett_output.txt") into GARNETT_OUTPUT
+             file("garnett_output.txt") into GARNETT_OUTPUT
 
         """
         RESULTS_DIR=\$PWD
         nextflow run $EVAL_WORKFLOWS/garnett-eval-workflow/main.nf\
-                            -profile cluster\
+                            -profile ${params.profile}\
                             --results_dir \$RESULTS_DIR\
                             --ref_10x_dir ${reference_10X_dir}\
                             --query_10x_dir ${query_10X_dir}\
@@ -175,12 +175,12 @@ if(params.scmap_cell.run == "True"){
             file(ref_metadata) from UNMELT_SDRF_REF
 
         output: 
-            file("final_scmap-cell_output.txt") into SCMAP_CELL_OUTPUT
+            file("scmap-cell_output.txt") into SCMAP_CELL_OUTPUT
 
         """
         RESULTS_DIR=\$PWD    
         nextflow run $EVAL_WORKFLOWS/scmap-eval-workflow/main.nf\
-                            -profile cluster\
+                            -profile ${params.profile}\
                             --results_dir \$RESULTS_DIR\
                             --projection_method ${params.scmap_cell.projection_method}\
                             --query_10x_dir ${query_10X_dir}\
@@ -215,12 +215,12 @@ if(params.scmap_cluster.run == "True"){
             file(ref_metadata) from UNMELT_SDRF_REF
 
         output:
-            file("final_scmap-cluster_output.txt") into SCMAP_CLUST_OUTPUT
+            file("scmap-cluster_output.txt") into SCMAP_CLUST_OUTPUT
 
         """
         RESULTS_DIR=\$PWD
         nextflow run $EVAL_WORKFLOWS/scmap-eval-workflow/main.nf\
-                            -profile cluster\
+                            -profile ${params.profile}\
                             --results_dir \$RESULTS_DIR\
                             --projection_method ${params.scmap_cluster.projection_method}\
                             --query_10x_dir ${query_10X_dir}\
@@ -254,12 +254,12 @@ if(params.scpred.run == "True"){
             file(ref_metadata) from UNMELT_SDRF_REF
 
         output:
-            file("final_scpred_output.txt") into SCPRED_OUTPUT
+            file("scpred_output.txt") into SCPRED_OUTPUT
 
         """
         RESULTS_DIR=\$PWD
         nextflow run $EVAL_WORKFLOWS/scpred-eval-workflow/main.nf\
-                            -profile cluster\
+                            -profile ${params.profile}\
                             --results_dir \$RESULTS_DIR\
                             --method ${params.scpred.method}\
                             -latest\

--- a/nextflow.config
+++ b/nextflow.config
@@ -32,7 +32,7 @@ params {
     
     // links to download data 
     data_download{
-        run = "False" // must be 'True' or 'False'      
+        run = "True" // must be 'True' or 'False'      
         expr_data_type = "normalised"
         normalisation_method = "TPM"
 
@@ -57,7 +57,7 @@ params {
     }
     
     scpred{
-	run = "False" // must be 'True' or 'False'
+	run = "True" // must be 'True' or 'False'
         results_dir = "" // specify output when in nested workflow
         method = "prediction" //must be 'evaluation' or 'prediction'
         training_10x_dir = ""
@@ -108,7 +108,7 @@ params {
     }
 
     garnett {
-	run = "False" // must be 'True' or 'False'
+	run = "True" // must be 'True' or 'False'
         results_dir = "" // specify output when in nested workflow
         ref_10x_dir = ""
         query_10x_dir = ""

--- a/nextflow.config
+++ b/nextflow.config
@@ -20,8 +20,9 @@ profiles {
 }
 
 params {
-    tool_outputs_dir ="${baseDir}/data/tools_outputs"
-    label_analysis_outdir ="${baseDir}/data/tools_outputs"
+    	profile = "standard"
+	tool_outputs_dir ="${baseDir}/data/tools_outputs"
+    	label_analysis_outdir ="${baseDir}/data/tools_outputs"
 
     // Specify input data. If data_download = 'False'
     ref_10x_dir = ""
@@ -116,8 +117,8 @@ params {
         query_cds_gene_id_type = "ENSEMBL"
         marker_genes = ""
         pval_col = "pvals"
-        groups_col = "groups"
-        gene_names = "names"
+        groups_col = "cluster"
+        gene_names = "genes"
 
 
         database = "org.Hs.eg.db"


### PR DESCRIPTION
DONE:
- [x] Remove `cell-types-eval-workflows` submodule. This repo contains individual workflows for predictors, and the label analysis. The strategy to follow will be fetching these repositories via a bash script. 
- [x] Enable all processes in config (some where set to run="False").
- [x] Restore tools output file name.
